### PR TITLE
Feature: HTTPS Server

### DIFF
--- a/cmd/qbin/main.go
+++ b/cmd/qbin/main.go
@@ -28,6 +28,9 @@ var flags = []cli.Flag{
 		Name: "http", EnvVar: "HTTP_LISTEN", Value: ":8000",
 		Usage: "HTTP listen address. Set to 'none' to disable."},
 	cli.StringFlag{
+		Name: "https", EnvVar: "HTTPS_LISTEN", Value: "none",
+		Usage: "HTTPS listen address, qbin will automatically get a Let's Encrypt certificate. Set to 'none' to disable."},
+	cli.StringFlag{
 		Name: "frontend-path, p", EnvVar: "FRONTEND_PATH", Value: "./frontend",
 		Usage: "Location of the frontend files."},
 	cli.BoolFlag{
@@ -78,8 +81,14 @@ func run(c *cli.Context) error {
 	}
 
 	// Serve HTTP
-	if c.String("http") != "none" {
-		go qbinHTTP.StartHTTP(c.String("http"), c.String("frontend-path"), c.String("root"))
+	if c.String("http") != "none" || c.String("https") != "none" {
+		go qbinHTTP.StartHTTP(qbinHTTP.Configuration{
+			ListenHTTP:    c.String("http"),
+			ListenHTTPS:   c.String("https"),
+			FrontendPath:  c.String("frontend-path"),
+			Root:          c.String("root"),
+			CertWhitelist: c.Args(),
+		})
 	}
 
 	// Serve TCP

--- a/cmd/qbin/main.go
+++ b/cmd/qbin/main.go
@@ -18,6 +18,9 @@ var flags = []cli.Flag{
 	cli.StringFlag{
 		Name: "root, r", EnvVar: "ROOT_URL", Value: "http://127.0.0.1:8000",
 		Usage: "The path under which the application will be reachable from the internet."},
+	cli.BoolFlag{
+		Name:  "force-root",
+		Usage: "If this is set, requests that are not on the root URI will be redirected."},
 	cli.StringFlag{
 		Name: "wordlist", EnvVar: "WORD_LIST", Value: "eff_large_wordlist.txt",
 		Usage: "Word list used for random slug generation."},
@@ -88,6 +91,7 @@ func run(c *cli.Context) error {
 			FrontendPath:  c.String("frontend-path"),
 			Root:          c.String("root"),
 			CertWhitelist: c.Args(),
+			ForceRoot:     c.Bool("force-root"),
 		})
 	}
 

--- a/http/helpers.go
+++ b/http/helpers.go
@@ -16,8 +16,8 @@ func escapeHTML(content string) string {
 
 // replaceGlobal replaces all global frontend variables with their config value.
 func replaceGlobal(content *string) {
-	replaceVariable(content, "path", config.path)
-	replaceVariable(content, "root", config.root)
+	replaceVariable(content, "path", config.Path)
+	replaceVariable(content, "root", config.Root)
 }
 
 // replaceVariable replaces a single frontend variable with its value.

--- a/http/helpers.go
+++ b/http/helpers.go
@@ -16,7 +16,7 @@ func escapeHTML(content string) string {
 
 // replaceGlobal replaces all global frontend variables with their config value.
 func replaceGlobal(content *string) {
-	replaceVariable(content, "path", config.Path)
+	replaceVariable(content, "path", config.path)
 	replaceVariable(content, "root", config.Root)
 }
 

--- a/http/routes.go
+++ b/http/routes.go
@@ -16,23 +16,23 @@ func setupRoutes(r *mux.Router) {
 	r.HandleFunc("/", uploadRoute).Methods("POST")
 
 	// Static aliased HTML files
-	r.HandleFunc("/", advancedStaticRoute(config.frontendPath, "/index.html", routeOptions{
+	r.HandleFunc("/", advancedStaticRoute(config.FrontendPath, "/index.html", routeOptions{
 		ignoreExceptions: true,
 		modifySource: func(body *string) {
 			replaceBlockVariable(body, "if_fork", false)
 		},
 	})).Methods("GET")
-	r.HandleFunc("/guidelines", staticRoute(config.frontendPath, "/guidelines.html", true)).Methods("GET")
+	r.HandleFunc("/guidelines", staticRoute(config.FrontendPath, "/guidelines.html", true)).Methods("GET")
 
 	// Static files
-	qbin.Log.Debugf("Including static files from: %s", config.frontendPath)
-	addStaticDirectory(config.frontendPath, "/", r)
+	qbin.Log.Debugf("Including static files from: %s", config.FrontendPath)
+	addStaticDirectory(config.FrontendPath, "/", r)
 
 	// Documents
 	r.HandleFunc("/{document}", documentRoute()).Methods("GET")
 	r.HandleFunc("/{document}/raw", rawDocumentRoute).Methods("GET")
 	r.HandleFunc("/{document}/fork", forkDocumentRoute()).Methods("GET")
-	r.HandleFunc("/{document}/report", advancedStaticRoute(config.frontendPath, "/report.html", routeOptions{
+	r.HandleFunc("/{document}/report", advancedStaticRoute(config.FrontendPath, "/report.html", routeOptions{
 		ignoreExceptions: true,
 		modifyResult: func(res http.ResponseWriter, req *http.Request, body *string) error {
 			replaceVariable(body, "id", strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/"), "/report"))
@@ -55,7 +55,7 @@ func rawDocumentRoute(res http.ResponseWriter, req *http.Request) {
 }
 
 func documentRoute() func(http.ResponseWriter, *http.Request) {
-	return advancedStaticRoute(config.frontendPath, "/output.html", routeOptions{
+	return advancedStaticRoute(config.FrontendPath, "/output.html", routeOptions{
 		ignoreExceptions: true,
 		modifyResult: func(res http.ResponseWriter, req *http.Request, body *string) error {
 			// TODO: Check for curl/wget requests and return raw document
@@ -80,7 +80,7 @@ func documentRoute() func(http.ResponseWriter, *http.Request) {
 }
 
 func forkDocumentRoute() func(http.ResponseWriter, *http.Request) {
-	return advancedStaticRoute(config.frontendPath, "/index.html", routeOptions{
+	return advancedStaticRoute(config.FrontendPath, "/index.html", routeOptions{
 		ignoreExceptions: true,
 		modifySource: func(body *string) {
 			replaceBlockVariable(body, "if_fork", true)

--- a/http/server.go
+++ b/http/server.go
@@ -46,7 +46,7 @@ func initializeConfig(initialConfig Configuration) {
 	if len(rootParts) > 3 { // Otherwise: application in root folder
 		config.path = rootParts[3]
 	}
-	config.path = "/" + strings.TrimPrefix(strings.TrimSuffix(config.path, "/"), "/")
+	config.path = strings.TrimSuffix("/"+strings.TrimPrefix(config.path, "/"), "/")
 
 	config.domain = strings.Split(strings.TrimPrefix(strings.ToLower(config.Root), "https://"), "/")[0]
 }

--- a/http/server.go
+++ b/http/server.go
@@ -1,61 +1,116 @@
 package qbinHTTP
 
 import (
+	"crypto/tls"
 	"net/http"
 	"path/filepath"
 	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/qbin-io/backend"
+	"github.com/urfave/negroni"
+	"golang.org/x/crypto/acme/autocert"
 )
 
-type configuration struct {
-	listen       string
-	frontendPath string
-	root         string
-	path         string
+type Configuration struct {
+	ListenHTTP    string
+	ListenHTTPS   string
+	FrontendPath  string
+	Root          string
+	Path          string
+	CertWhitelist []string
 }
 
-var config configuration
+var config Configuration
 
 // initializeConfig will normalize the options and create the "config" object.
-func initializeConfig(listen string, frontendPath string, root string) {
+func initializeConfig(initialConfig Configuration) {
+	config = initialConfig
 	// Transform frontendPath to an absolute path
-	frontendPath, err := filepath.Abs(frontendPath)
+	frontendPath, err := filepath.Abs(config.FrontendPath)
 	if err != nil {
 		qbin.Log.Critical("Frontend path couldn't be resolved.")
 		panic(err)
 	}
+	config.FrontendPath = frontendPath
 
-	root = strings.TrimSuffix(root, "/")
+	config.Root = strings.TrimSuffix(config.Root, "/")
 
 	// Extract "path" fron "root"
-	rootParts := strings.SplitAfterN(root, "/", 4) // https://example.org/[grab this part]
-	path := "/"
+	rootParts := strings.SplitAfterN(config.Root, "/", 4) // https://example.org/[grab this part]
+	config.Path = "/"
 	if len(rootParts) > 3 { // Otherwise: application in root folder
-		path = "/" + rootParts[3]
+		config.Path = "/" + rootParts[3]
 	}
-	path = strings.TrimSuffix(path, "/")
-
-	config = configuration{listen, frontendPath, root, path}
+	config.Path = strings.TrimSuffix(config.Path, "/")
 }
 
 // StartHTTP launches the HTTP server which is responsible for the frontend and the HTTP API.
-func StartHTTP(listen string, frontendPath string, root string) {
+func StartHTTP(initialConfig Configuration) {
 	// Configure
 	qbin.Log.Debug("Initializing HTTP server...")
-	initializeConfig(listen, frontendPath, root)
+	initializeConfig(initialConfig)
 
 	// Route
 	qbin.Log.Debug("Setting up routes...")
 	r := mux.NewRouter()
 	setupRoutes(r)
 
+	// Middlewares
+	n := negroni.Classic()
+	n.UseHandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Add("Server", "qbin")
+	})
+	n.UseHandler(r)
+
 	// Serve
-	qbin.Log.Noticef("HTTP server starting on %s, you should be able to reach it at %s", config.listen, config.root)
-	err := http.ListenAndServe(config.listen, r)
+	if config.ListenHTTPS != "none" {
+		qbin.Log.Noticef("HTTPS server starting on %s for redirection", config.ListenHTTP)
+		go listenHTTP(redirector{})
+		if config.ListenHTTP != "none" {
+			qbin.Log.Noticef("HTTPS server starting on %s, you should be able to reach it at %s", config.ListenHTTPS, config.Root)
+			go listenHTTPS(n)
+		}
+	} else {
+		qbin.Log.Noticef("HTTP server starting on %s, you should be able to reach it at %s", config.ListenHTTP, config.Root)
+		go listenHTTP(n)
+	}
+}
+
+func listenHTTPS(r http.Handler) {
+	certManager := autocert.Manager{
+		Prompt:     autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(config.CertWhitelist...),
+		Cache:      autocert.DirCache("certs"),
+	}
+	server := &http.Server{
+		Addr:    config.ListenHTTPS,
+		Handler: r,
+		TLSConfig: &tls.Config{
+			GetCertificate: certManager.GetCertificate,
+		},
+	}
+
+	err := server.ListenAndServeTLS("", "")
+	if err != nil {
+		qbin.Log.Criticalf("HTTPS server error: %s", err)
+		panic(err)
+	}
+}
+
+func listenHTTP(r http.Handler) {
+	err := http.ListenAndServe(config.ListenHTTP, r)
 	if err != nil {
 		qbin.Log.Criticalf("HTTP server error: %s", err)
 		panic(err)
 	}
+}
+
+type redirector struct{}
+
+func (redirector) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	res.Header().Add("Server", "qbin")
+	res.Header().Add("Location", config.Root+req.URL.EscapedPath())
+	res.WriteHeader(301)
+	res.Write([]byte(""))
 }

--- a/http/server.go
+++ b/http/server.go
@@ -23,6 +23,7 @@ type Configuration struct {
 	domain        string
 	CertWhitelist []string
 	ForceRoot     bool
+	Hsts          string
 }
 
 var config Configuration
@@ -67,6 +68,10 @@ func StartHTTP(initialConfig Configuration) {
 	// Add important headers
 	n.UseHandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.Header().Add("Server", "qbin")
+		res.Header().Add("X-Content-Type", "nosniff") // We're not a CDN.
+		if config.Hsts != "" {
+			res.Header().Add("Strict-Transport-Security", config.Hsts)
+		}
 	})
 	// Redirect to root
 	if config.ForceRoot {


### PR DESCRIPTION
Add fully automated HTTPS Server using Let's Encrypt. This also adds the `--force-root` flag to automatically redirect to the correct domain (HTTP -> HTTPS redirects are always active and not affected by this option), and changes some variable names (the configuration has to be more flexible to allow for the many new settings).